### PR TITLE
resolve #13 spring bootとDBの接続

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/twitter_like
+    url: jdbc:mysql://127.0.0.1:3306/twitter_like_app
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+management:
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
# 概要

Spring Boot Actuatorを利用することで簡単にヘルスチェックが実現できそうだったため導入

# 動作確認
localhost:8080/actuator/healthからdbに接続できていることを確認
```
{
    "status": "UP",
    "components": {
        "db": {
            "status": "UP",
            "details": {
                "database": "MySQL",
                "validationQuery": "isValid()"
            }
        },
        "diskSpace": {
            "status": "UP",
            "details": {
                "total": 499963174912,
                "free": 190752161792,
                "threshold": 10485760,
                "exists": true
            }
        },
        "ping": {
            "status": "UP"
        }
    }
}
```